### PR TITLE
[Z80] Support fminimum_num / fmaximum_num

### DIFF
--- a/compiler-rt/lib/builtins/sm83/fmaximum_numf.asm
+++ b/compiler-rt/lib/builtins/sm83/fmaximum_numf.asm
@@ -1,0 +1,136 @@
+; SPDX-License-Identifier: Zlib OR Apache-2.0 WITH LLVM-exception OR MIT
+	.area _CODE
+	.globl _fmaximum_numf
+
+;===------------------------------------------------------------------------===;
+; _fmaximum_numf - IEEE-754 2019 maximumNumber for floats (SM83)
+;
+; Input:  DEBC = a, stack = b  (callee-cleanup for b)
+; Output: DEBC = maximumNumber(a, b)
+;         If one is NaN, return the other. For equal values honors signed-zero
+;         order (-0 < +0): the result is +0 unless both operands are -0.
+;
+; Differs from fmaxf (maxNum) only in that signed-zero handling. With
+; -ffast-math (nsz) the backend uses fmaxf instead.
+;
+; SM83 stack frame (no IX): saved_a(4) + ret_addr(2) + b(4).
+;===------------------------------------------------------------------------===;
+_fmaximum_numf:
+	push	de		; a high
+	push	bc		; a low
+	; SP+0..1: a_C,a_B  SP+2..3: a_E,a_D  SP+4..5: ret  SP+6..9: b_C,b_B,b_E,b_D
+
+	; NaN check a
+	ld	a, d
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fmaximumf_a_ok
+	bit	7, e
+	jr	z, __fmaximumf_a_ok
+	ld	a, e
+	and	#0x7F
+	or	b
+	or	c
+	jr	nz, __fmaximumf_ret_b
+__fmaximumf_a_ok:
+
+	; NaN check b
+	ld	hl, #9
+	add	hl, sp
+	ld	a, (hl)		; b_D
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fmaximumf_cmp
+	dec	hl		; b_E
+	bit	7, (hl)
+	jr	z, __fmaximumf_cmp
+	ld	a, (hl)
+	and	#0x7F
+	dec	hl		; b_B
+	or	(hl)
+	dec	hl		; b_C
+	or	(hl)
+	jr	nz, __fmaximumf_ret_a
+
+__fmaximumf_cmp:
+	; Push b copy for cmpsf2
+	ld	hl, #8
+	add	hl, sp		; → b_E
+	ld	a, (hl)
+	inc	hl		; b_D
+	ld	h, (hl)
+	ld	l, a		; HL = b_D:b_E
+	push	hl		; D2:E2
+	ld	hl, #8
+	add	hl, sp		; → b_C (stack grew by 2)
+	ld	a, (hl)
+	inc	hl		; b_B
+	ld	h, (hl)
+	ld	l, a		; HL = b_B:b_C
+	push	hl		; B2:C2
+
+	; Reload a into DEBC
+	ld	hl, #4
+	add	hl, sp		; → a_C (stack grew by 4)
+	ld	c, (hl)
+	inc	hl
+	ld	b, (hl)
+	inc	hl
+	ld	e, (hl)
+	inc	hl
+	ld	d, (hl)
+	call	___cmpsf2	; callee-cleanup removes 4, BC = result
+	bit	7, b
+	jr	nz, __fmaximumf_ret_b	; a < b → b
+	ld	a, b
+	or	c
+	jr	nz, __fmaximumf_ret_a	; a > b → a
+
+	; a == b: result = a, sign = sign(a) & sign(b).
+	ld	hl, #0
+	add	hl, sp
+	ld	c, (hl)		; a_C
+	inc	hl
+	ld	b, (hl)		; a_B
+	inc	hl
+	ld	e, (hl)		; a_E
+	inc	hl
+	ld	d, (hl)		; a_D
+	ld	hl, #9
+	add	hl, sp
+	bit	7, (hl)		; sign of b
+	jr	nz, __fmaximumf_done
+	res	7, d		; b is +0 → result +0
+	jr	__fmaximumf_done
+
+__fmaximumf_ret_b:
+	ld	hl, #6
+	add	hl, sp
+	ld	c, (hl)
+	inc	hl
+	ld	b, (hl)
+	inc	hl
+	ld	e, (hl)
+	inc	hl
+	ld	d, (hl)
+	jr	__fmaximumf_done
+
+__fmaximumf_ret_a:
+	pop	bc		; a low
+	pop	de		; a high
+	pop	hl		; ret addr
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	jp	(hl)
+
+__fmaximumf_done:
+	pop	hl		; discard a low
+	pop	hl		; discard a high
+	pop	hl		; ret addr
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	jp	(hl)

--- a/compiler-rt/lib/builtins/sm83/fmaximum_numf.asm
+++ b/compiler-rt/lib/builtins/sm83/fmaximum_numf.asm
@@ -10,8 +10,7 @@
 ;         If one is NaN, return the other. For equal values honors signed-zero
 ;         order (-0 < +0): the result is +0 unless both operands are -0.
 ;
-; Differs from fmaxf (maxNum) only in that signed-zero handling. With
-; -ffast-math (nsz) the backend uses fmaxf instead.
+; Differs from fmaxf (maxNum) only in signed-zero handling.
 ;
 ; SM83 stack frame (no IX): saved_a(4) + ret_addr(2) + b(4).
 ;===------------------------------------------------------------------------===;

--- a/compiler-rt/lib/builtins/sm83/fminimum_numf.asm
+++ b/compiler-rt/lib/builtins/sm83/fminimum_numf.asm
@@ -1,0 +1,136 @@
+; SPDX-License-Identifier: Zlib OR Apache-2.0 WITH LLVM-exception OR MIT
+	.area _CODE
+	.globl _fminimum_numf
+
+;===------------------------------------------------------------------------===;
+; _fminimum_numf - IEEE-754 2019 minimumNumber for floats (SM83)
+;
+; Input:  DEBC = a, stack = b  (callee-cleanup for b)
+; Output: DEBC = minimumNumber(a, b)
+;         If one is NaN, return the other. For equal values honors signed-zero
+;         order (-0 < +0): if either operand is -0 the result is -0.
+;
+; Differs from fminf (minNum) only in that signed-zero handling. With
+; -ffast-math (nsz) the backend uses fminf instead.
+;
+; SM83 stack frame (no IX): saved_a(4) + ret_addr(2) + b(4).
+;===------------------------------------------------------------------------===;
+_fminimum_numf:
+	push	de		; a high
+	push	bc		; a low
+	; SP+0..1: a_C,a_B  SP+2..3: a_E,a_D  SP+4..5: ret  SP+6..9: b_C,b_B,b_E,b_D
+
+	; NaN check a
+	ld	a, d
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fminimumf_a_ok
+	bit	7, e
+	jr	z, __fminimumf_a_ok
+	ld	a, e
+	and	#0x7F
+	or	b
+	or	c
+	jr	nz, __fminimumf_ret_b
+__fminimumf_a_ok:
+
+	; NaN check b
+	ld	hl, #9
+	add	hl, sp
+	ld	a, (hl)		; b_D
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fminimumf_cmp
+	dec	hl		; b_E
+	bit	7, (hl)
+	jr	z, __fminimumf_cmp
+	ld	a, (hl)
+	and	#0x7F
+	dec	hl		; b_B
+	or	(hl)
+	dec	hl		; b_C
+	or	(hl)
+	jr	nz, __fminimumf_ret_a
+
+__fminimumf_cmp:
+	; Push b copy for cmpsf2
+	ld	hl, #8
+	add	hl, sp		; → b_E
+	ld	a, (hl)
+	inc	hl		; b_D
+	ld	h, (hl)
+	ld	l, a		; HL = b_D:b_E
+	push	hl		; D2:E2
+	ld	hl, #8
+	add	hl, sp		; → b_C (stack grew by 2)
+	ld	a, (hl)
+	inc	hl		; b_B
+	ld	h, (hl)
+	ld	l, a		; HL = b_B:b_C
+	push	hl		; B2:C2
+
+	; Reload a into DEBC
+	ld	hl, #4
+	add	hl, sp		; → a_C (stack grew by 4)
+	ld	c, (hl)
+	inc	hl
+	ld	b, (hl)
+	inc	hl
+	ld	e, (hl)
+	inc	hl
+	ld	d, (hl)
+	call	___cmpsf2	; callee-cleanup removes 4, BC = result
+	bit	7, b
+	jr	nz, __fminimumf_ret_a	; a < b → a
+	ld	a, b
+	or	c
+	jr	nz, __fminimumf_ret_b	; a > b → b
+
+	; a == b: result = a, sign = sign(a) | sign(b).
+	ld	hl, #0
+	add	hl, sp
+	ld	c, (hl)		; a_C
+	inc	hl
+	ld	b, (hl)		; a_B
+	inc	hl
+	ld	e, (hl)		; a_E
+	inc	hl
+	ld	d, (hl)		; a_D
+	ld	hl, #9
+	add	hl, sp
+	bit	7, (hl)		; sign of b
+	jr	z, __fminimumf_done
+	set	7, d		; either operand -0 → result -0
+	jr	__fminimumf_done
+
+__fminimumf_ret_b:
+	ld	hl, #6
+	add	hl, sp
+	ld	c, (hl)
+	inc	hl
+	ld	b, (hl)
+	inc	hl
+	ld	e, (hl)
+	inc	hl
+	ld	d, (hl)
+	jr	__fminimumf_done
+
+__fminimumf_ret_a:
+	pop	bc		; a low
+	pop	de		; a high
+	pop	hl		; ret addr
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	jp	(hl)
+
+__fminimumf_done:
+	pop	hl		; discard a low
+	pop	hl		; discard a high
+	pop	hl		; ret addr
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	jp	(hl)

--- a/compiler-rt/lib/builtins/sm83/fminimum_numf.asm
+++ b/compiler-rt/lib/builtins/sm83/fminimum_numf.asm
@@ -10,8 +10,7 @@
 ;         If one is NaN, return the other. For equal values honors signed-zero
 ;         order (-0 < +0): if either operand is -0 the result is -0.
 ;
-; Differs from fminf (minNum) only in that signed-zero handling. With
-; -ffast-math (nsz) the backend uses fminf instead.
+; Differs from fminf (minNum) only in signed-zero handling.
 ;
 ; SM83 stack frame (no IX): saved_a(4) + ret_addr(2) + b(4).
 ;===------------------------------------------------------------------------===;

--- a/compiler-rt/lib/builtins/z80/fmaximum_numf.asm
+++ b/compiler-rt/lib/builtins/z80/fmaximum_numf.asm
@@ -11,8 +11,7 @@
 ;         For equal values it honors signed-zero order (-0 < +0): the result
 ;         is +0 unless both operands are -0.
 ;
-; Differs from fmaxf (maxNum) only in that signed-zero handling. With
-; -ffast-math (nsz) the backend uses fmaxf instead.
+; Differs from fmaxf (maxNum) only in signed-zero handling.
 ;
 ; Uses ___cmpsf2 (callee-cleanup, returns DE: -1/0/+1).
 ;===------------------------------------------------------------------------===;

--- a/compiler-rt/lib/builtins/z80/fmaximum_numf.asm
+++ b/compiler-rt/lib/builtins/z80/fmaximum_numf.asm
@@ -1,0 +1,107 @@
+; SPDX-License-Identifier: Zlib OR Apache-2.0 WITH LLVM-exception OR MIT
+	.area _CODE
+	.globl _fmaximum_numf
+
+;===------------------------------------------------------------------------===;
+; _fmaximum_numf - IEEE-754 2019 maximumNumber for floats (C23 fmaximum_numf)
+;
+; Input:  HLDE = a, stack = b  (callee-cleanup for b)
+; Output: HLDE = maximumNumber(a, b)
+;         If one is NaN, return the other.
+;         For equal values it honors signed-zero order (-0 < +0): the result
+;         is +0 unless both operands are -0.
+;
+; Differs from fmaxf (maxNum) only in that signed-zero handling. With
+; -ffast-math (nsz) the backend uses fmaxf instead.
+;
+; Uses ___cmpsf2 (callee-cleanup, returns DE: -1/0/+1).
+;===------------------------------------------------------------------------===;
+_fmaximum_numf:
+	push	ix
+	ld	ix, #0
+	add	ix, sp
+	; IX+4..7: b (E2,D2,L2,H2)
+
+	push	hl		; IX-2: a_L, IX-1: a_H
+	push	de		; IX-4: a_E, IX-3: a_D
+
+	; --- NaN check: a ---
+	ld	a, h
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fmaximumf_a_ok
+	bit	7, l
+	jr	z, __fmaximumf_a_ok
+	ld	a, l
+	and	#0x7F
+	or	d
+	or	e
+	jr	nz, __fmaximumf_ret_b	; a is NaN → return b
+__fmaximumf_a_ok:
+
+	; --- NaN check: b ---
+	ld	a, 7(ix)
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fmaximumf_cmp
+	bit	7, 6(ix)
+	jr	z, __fmaximumf_cmp
+	ld	a, 6(ix)
+	and	#0x7F
+	or	5(ix)
+	or	4(ix)
+	jr	nz, __fmaximumf_ret_a	; b is NaN → return a
+
+__fmaximumf_cmp:
+	ld	b, 7(ix)
+	ld	c, 6(ix)
+	push	bc		; H2:L2
+	ld	b, 5(ix)
+	ld	c, 4(ix)
+	push	bc		; D2:E2
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+	call	___cmpsf2	; callee-cleanup removes 4 bytes, DE = result
+	bit	7, d
+	jr	nz, __fmaximumf_ret_b	; a < b → return b
+	ld	a, d
+	or	e
+	jr	nz, __fmaximumf_ret_a	; a > b → return a
+
+	; a == b: signed-zero order. result = a, sign = sign(a) & sign(b).
+	; (For non-zero equals the sign bits match, so this is a no-op there.)
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+	bit	7, 7(ix)	; sign of b
+	jr	nz, __fmaximumf_done
+	res	7, h		; b is +0 → result is +0
+	jr	__fmaximumf_done
+
+__fmaximumf_ret_b:
+	ld	h, 7(ix)
+	ld	l, 6(ix)
+	ld	d, 5(ix)
+	ld	e, 4(ix)
+	jr	__fmaximumf_done
+
+__fmaximumf_ret_a:
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+
+__fmaximumf_done:
+	ld	sp, ix		; discard saved a
+	pop	ix
+	; Callee-cleanup: skip 4 bytes of b
+	pop	bc		; return address
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	push	bc
+	ret

--- a/compiler-rt/lib/builtins/z80/fminimum_numf.asm
+++ b/compiler-rt/lib/builtins/z80/fminimum_numf.asm
@@ -1,0 +1,107 @@
+; SPDX-License-Identifier: Zlib OR Apache-2.0 WITH LLVM-exception OR MIT
+	.area _CODE
+	.globl _fminimum_numf
+
+;===------------------------------------------------------------------------===;
+; _fminimum_numf - IEEE-754 2019 minimumNumber for floats (C23 fminimum_numf)
+;
+; Input:  HLDE = a, stack = b  (callee-cleanup for b)
+; Output: HLDE = minimumNumber(a, b)
+;         If one is NaN, return the other.
+;         For equal values it honors signed-zero order (-0 < +0): if either
+;         operand is -0, the result is -0.
+;
+; Differs from fminf (minNum) only in that signed-zero handling. With
+; -ffast-math (nsz) the backend uses fminf instead.
+;
+; Uses ___cmpsf2 (callee-cleanup, returns DE: -1/0/+1).
+;===------------------------------------------------------------------------===;
+_fminimum_numf:
+	push	ix
+	ld	ix, #0
+	add	ix, sp
+	; IX+4..7: b (E2,D2,L2,H2)
+
+	push	hl		; IX-2: a_L, IX-1: a_H
+	push	de		; IX-4: a_E, IX-3: a_D
+
+	; --- NaN check: a ---
+	ld	a, h
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fminimumf_a_ok
+	bit	7, l
+	jr	z, __fminimumf_a_ok
+	ld	a, l
+	and	#0x7F
+	or	d
+	or	e
+	jr	nz, __fminimumf_ret_b	; a is NaN → return b
+__fminimumf_a_ok:
+
+	; --- NaN check: b ---
+	ld	a, 7(ix)
+	and	#0x7F
+	cp	#0x7F
+	jr	nz, __fminimumf_cmp
+	bit	7, 6(ix)
+	jr	z, __fminimumf_cmp
+	ld	a, 6(ix)
+	and	#0x7F
+	or	5(ix)
+	or	4(ix)
+	jr	nz, __fminimumf_ret_a	; b is NaN → return a
+
+__fminimumf_cmp:
+	ld	b, 7(ix)
+	ld	c, 6(ix)
+	push	bc		; H2:L2
+	ld	b, 5(ix)
+	ld	c, 4(ix)
+	push	bc		; D2:E2
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+	call	___cmpsf2	; callee-cleanup removes 4 bytes, DE = result
+	bit	7, d
+	jr	nz, __fminimumf_ret_a	; a < b → return a
+	ld	a, d
+	or	e
+	jr	nz, __fminimumf_ret_b	; a > b → return b
+
+	; a == b: signed-zero order. result = a, sign = sign(a) | sign(b).
+	; (For non-zero equals the sign bits match, so this is a no-op there.)
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+	bit	7, 7(ix)	; sign of b
+	jr	z, __fminimumf_done
+	set	7, h		; either operand is -0 → result is -0
+	jr	__fminimumf_done
+
+__fminimumf_ret_b:
+	ld	h, 7(ix)
+	ld	l, 6(ix)
+	ld	d, 5(ix)
+	ld	e, 4(ix)
+	jr	__fminimumf_done
+
+__fminimumf_ret_a:
+	ld	h, -1(ix)
+	ld	l, -2(ix)
+	ld	d, -3(ix)
+	ld	e, -4(ix)
+
+__fminimumf_done:
+	ld	sp, ix		; discard saved a
+	pop	ix
+	; Callee-cleanup: skip 4 bytes of b
+	pop	bc		; return address
+	inc	sp
+	inc	sp
+	inc	sp
+	inc	sp
+	push	bc
+	ret

--- a/compiler-rt/lib/builtins/z80/fminimum_numf.asm
+++ b/compiler-rt/lib/builtins/z80/fminimum_numf.asm
@@ -11,8 +11,7 @@
 ;         For equal values it honors signed-zero order (-0 < +0): if either
 ;         operand is -0, the result is -0.
 ;
-; Differs from fminf (minNum) only in that signed-zero handling. With
-; -ffast-math (nsz) the backend uses fminf instead.
+; Differs from fminf (minNum) only in signed-zero handling.
 ;
 ; Uses ___cmpsf2 (callee-cleanup, returns DE: -1/0/+1).
 ;===------------------------------------------------------------------------===;

--- a/llvm/lib/Target/Z80/Z80LegalizerInfo.cpp
+++ b/llvm/lib/Target/Z80/Z80LegalizerInfo.cpp
@@ -489,6 +489,15 @@ Z80LegalizerInfo::Z80LegalizerInfo(const Z80Subtarget &STI) {
 
   getActionDefinitionsBuilder({G_FMINNUM, G_FMAXNUM}).libcallFor({S32, S64});
 
+  // minimumNumber/maximumNumber (IEEE-754 2019). For f32, custom-legalize so
+  // that with -ffast-math (nsz) we drop to the cheaper minnum/maxnum (fminf/
+  // fmaxf, which ignore -0/+0 ordering), and otherwise call the precise
+  // fminimum_numf/fmaximum_numf. f64 has no soft-float runtime here, so it
+  // libcalls fminimum_num/fmaximum_num (provided externally, like f64 fmin).
+  getActionDefinitionsBuilder({G_FMINIMUMNUM, G_FMAXIMUMNUM})
+      .customFor({S32})
+      .libcallFor({S64});
+
   // FP rounding functions — libcalls for both f32 and f64.
   getActionDefinitionsBuilder({G_FFLOOR, G_FCEIL, G_FRINT, G_FNEARBYINT,
                                G_INTRINSIC_TRUNC, G_INTRINSIC_ROUND,
@@ -731,6 +740,37 @@ bool Z80LegalizerInfo::legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI,
       llvm_unreachable("unexpected opcode");
     }
 
+    auto Status = Helper.createLibcall(FuncName, {Dst, F32Ty, 0},
+                                       {{LHS, F32Ty, 0}, {RHS, F32Ty, 1}},
+                                       CallingConv::C, LocObserver, &MI);
+    if (Status != LegalizerHelper::Legalized)
+      return false;
+    MI.eraseFromParent();
+    return true;
+  }
+
+  case TargetOpcode::G_FMINIMUMNUM:
+  case TargetOpcode::G_FMAXIMUMNUM: {
+    bool IsMin = MI.getOpcode() == TargetOpcode::G_FMINIMUMNUM;
+    Register Dst = MI.getOperand(0).getReg();
+    Register LHS = MI.getOperand(1).getReg();
+    Register RHS = MI.getOperand(2).getReg();
+
+    if (MI.getFlag(MachineInstr::FmNsz)) {
+      // -ffast-math (no signed zeros): minimumNumber/maximumNumber collapse to
+      // the cheaper minnum/maxnum (fminf/fmaxf), which ignore -0/+0 ordering.
+      MIRBuilder.buildInstr(IsMin ? TargetOpcode::G_FMINNUM
+                                  : TargetOpcode::G_FMAXNUM,
+                            {Dst}, {LHS, RHS}, MI.getFlags());
+      MI.eraseFromParent();
+      return true;
+    }
+
+    // Precise IEEE-754 2019 minimumNumber/maximumNumber libcall.
+    MachineFunction &MF = MIRBuilder.getMF();
+    auto &Ctx = MF.getFunction().getContext();
+    Type *F32Ty = Type::getFloatTy(Ctx);
+    const char *FuncName = IsMin ? "fminimum_numf" : "fmaximum_numf";
     auto Status = Helper.createLibcall(FuncName, {Dst, F32Ty, 0},
                                        {{LHS, F32Ty, 0}, {RHS, F32Ty, 1}},
                                        CallingConv::C, LocObserver, &MI);

--- a/llvm/lib/Target/Z80/Z80LegalizerInfo.cpp
+++ b/llvm/lib/Target/Z80/Z80LegalizerInfo.cpp
@@ -29,7 +29,6 @@
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/IntrinsicsZ80.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/WithColor.h"
 
 using namespace llvm;
 
@@ -41,31 +40,7 @@ static bool hasAllFastFlags(const MachineInstr &MI,
   bool NoNans = MI.getFlag(MachineInstr::FmNoNans);
   bool NoInfs = MI.getFlag(MachineInstr::FmNoInfs);
   bool Nsz = MI.getFlag(MachineInstr::FmNsz);
-  if (NoNans && NoInfs && Nsz)
-    return true;
-  if (NoNans || NoInfs || Nsz) {
-    static bool Warned = false;
-    if (!Warned) {
-      Warned = true;
-      WithColor::warning() << "partial fast-math flags (have:";
-      auto &OS = errs();
-      if (NoNans)
-        OS << " nnan";
-      if (NoInfs)
-        OS << " ninf";
-      if (Nsz)
-        OS << " nsz";
-      OS << ", missing:";
-      if (!NoNans)
-        OS << " nnan";
-      if (!NoInfs)
-        OS << " ninf";
-      if (!Nsz)
-        OS << " nsz";
-      OS << ") - need all three for fast soft-float path\n";
-    }
-  }
-  return false;
+  return NoNans && NoInfs && Nsz;
 }
 
 Z80LegalizerInfo::Z80LegalizerInfo(const Z80Subtarget &STI) {

--- a/z80-utils/elf2rel/src/main.rs
+++ b/z80-utils/elf2rel/src/main.rs
@@ -188,14 +188,32 @@ fn write_ar(members: &[ArMember]) -> Vec<u8> {
         0
     };
 
+    // Build the GNU extended-name table for members whose "<name>/" does not
+    // fit in the 16-byte name field (name longer than 15 bytes). Each long name
+    // is stored as "<name>/\n" in a "//" member; the member's own name field
+    // then becomes "/<byte-offset-into-the-table>".
+    let mut ext_table: Vec<u8> = Vec::new();
+    let mut ext_offset: Vec<Option<usize>> = Vec::with_capacity(members.len());
+    for member in members {
+        if member.name.len() + 1 > 16 {
+            ext_offset.push(Some(ext_table.len()));
+            ext_table.extend_from_slice(member.name.as_bytes());
+            ext_table.extend_from_slice(b"/\n");
+        } else {
+            ext_offset.push(None);
+        }
+    }
+    let ext_total = if ext_table.is_empty() {
+        0
+    } else {
+        60 + ext_table.len() + (ext_table.len() % 2)
+    };
+
     // Compute offset of each data member from start of file
     let mut member_offsets = Vec::with_capacity(members.len());
-    let mut offset = 8 + symtab_total; // 8 = AR_MAGIC
+    let mut offset = 8 + symtab_total + ext_total; // 8 = AR_MAGIC
     for member in members {
         member_offsets.push(offset);
-        let name_field = format!("{}/", member.name);
-        let header_name_len = if name_field.len() > 16 { 16 } else { name_field.len() };
-        let _ = header_name_len; // member header is always 60 bytes
         offset += 60 + member.data.len();
         if member.data.len() % 2 != 0 {
             offset += 1; // padding
@@ -228,9 +246,27 @@ fn write_ar(members: &[ArMember]) -> Vec<u8> {
         }
     }
 
+    // Write the "//" extended-name member (holds the long member names).
+    if !ext_table.is_empty() {
+        write!(buf, "{:<16}", "//").unwrap();
+        write!(buf, "{:<12}", "0").unwrap();
+        write!(buf, "{:<6}", "0").unwrap();
+        write!(buf, "{:<6}", "0").unwrap();
+        write!(buf, "{:<8}", "0").unwrap();
+        write!(buf, "{:<10}", ext_table.len()).unwrap();
+        buf.extend_from_slice(b"`\n");
+        buf.extend_from_slice(&ext_table);
+        if ext_table.len() % 2 != 0 {
+            buf.push(b'\n');
+        }
+    }
+
     // Write data members
-    for member in members {
-        let name_field = format!("{}/", member.name);
+    for (idx, member) in members.iter().enumerate() {
+        let name_field = match ext_offset[idx] {
+            Some(off) => format!("/{}", off),
+            None => format!("{}/", member.name),
+        };
         write!(buf, "{:<16}", name_field).unwrap();
         write!(buf, "{:<12}", "0").unwrap();
         write!(buf, "{:<6}", "0").unwrap();

--- a/z80-utils/test-runner/src/config.rs
+++ b/z80-utils/test-runner/src/config.rs
@@ -185,11 +185,6 @@ impl Paths {
         self.build_dir.join(format!("lib/{t}/{t}_crt0.rel"))
     }
 
-    pub fn rt_rel(&self, target: Target) -> PathBuf {
-        let t = target.triple();
-        self.build_dir.join(format!("lib/{t}/{t}_rt.rel"))
-    }
-
     pub fn rt_lib(&self, target: Target) -> PathBuf {
         let t = target.triple();
         self.build_dir.join(format!("lib/{t}/{t}_rt.lib"))

--- a/z80-utils/test-runner/src/run_all.rs
+++ b/z80-utils/test-runner/src/run_all.rs
@@ -485,10 +485,13 @@ fn add_utils(
     suites.push(SuiteDef {
         label: label.clone(),
         runner: Box::new(move |paths, state, idx| {
-            // Pre-count: 6 groups × number of clang test files
-            let test_dir = paths.clang_test_dir();
-            let test_count = crate::suite::discover_tests(&test_dir, "test_", "c").len() as u32;
-            state.lock().unwrap()[idx].total = test_count * 6;
+            // Pre-count: 4 groups iterate the clang tests; the 2 crosslink
+            // groups iterate the (smaller) sdcc cross-validation test set.
+            let clang_count =
+                crate::suite::discover_tests(&paths.clang_test_dir(), "test_", "c").len() as u32;
+            let sdcc_count =
+                crate::utils::discover_sdcc_test_names(&paths.sdcc_test_dir()).len() as u32;
+            state.lock().unwrap()[idx].total = clang_count * 4 + sdcc_count * 2;
 
             let config = UtilsConfig { target, opt: OptLevel::O1, pattern: None };
             let mut cb = progress_callback(state.clone(), idx);

--- a/z80-utils/test-runner/src/sdcc.rs
+++ b/z80-utils/test-runner/src/sdcc.rs
@@ -164,7 +164,7 @@ fn run_single(
     let out_base = tmp_dir.join(tag);
     {
         let crt0 = paths.crt0(target);
-        let rt = paths.rt_rel(target);
+        let rt = paths.rt_lib(target);
 
         let mut cmd = Command::new(linker);
         cmd.args(["-m", "-i"]);

--- a/z80-utils/test-runner/src/utils.rs
+++ b/z80-utils/test-runner/src/utils.rs
@@ -997,7 +997,7 @@ fn test_rel_ar_roundtrip(
 
 // ── Shared utilities ────────────────────────────────────────────────────────
 
-fn discover_sdcc_test_names(test_dir: &Path) -> Vec<String> {
+pub(crate) fn discover_sdcc_test_names(test_dir: &Path) -> Vec<String> {
     let mut names: Vec<String> = std::fs::read_dir(test_dir)
         .into_iter()
         .flatten()

--- a/z80-utils/test-runner/testcases/clang/test_59_f32_minimumnum.c
+++ b/z80-utils/test-runner/testcases/clang/test_59_f32_minimumnum.c
@@ -4,7 +4,6 @@
    (-0 < +0). Under -ffast-math these collapse to fminf/fmaxf, where the
    signed-zero result is unspecified, so skip there. */
 /* SKIP-IF: -ffast-math */
-typedef unsigned char uint8_t;
 typedef unsigned short uint16_t;
 typedef unsigned long uint32_t;
 

--- a/z80-utils/test-runner/testcases/clang/test_59_f32_minimumnum.c
+++ b/z80-utils/test-runner/testcases/clang/test_59_f32_minimumnum.c
@@ -1,0 +1,94 @@
+/* Test 59: IEEE 754-2019 minimumNumber / maximumNumber (f32) */
+/* Exercises G_FMINIMUMNUM/G_FMAXIMUMNUM legalization and the
+   fminimum_numf / fmaximum_numf runtime, including precise signed-zero order
+   (-0 < +0). Under -ffast-math these collapse to fminf/fmaxf, where the
+   signed-zero result is unspecified, so skip there. */
+/* SKIP-IF: -ffast-math */
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+
+typedef union { float f; uint32_t u; } f32u;
+
+static float mk(uint32_t u) { f32u x; x.u = u; return x.f; }
+static uint32_t f2u(float f) { f32u x; x.f = f; return x.u; }
+
+#define PZERO 0x00000000UL /* +0.0 */
+#define NZERO 0x80000000UL /* -0.0 */
+#define QNAN  0x7FC00000UL /* quiet NaN */
+
+int main() {
+    uint16_t status = 0;
+
+    /* === Ordinary selection === */
+
+    /* Bit 0: minimumNumber(2, 3) == 2 */
+    { volatile float a = 2.0f, b = 3.0f;
+      if (__builtin_fminimum_numf(a, b) == 2.0f) status |= (1 << 0); }
+
+    /* Bit 1: minimumNumber(3, 2) == 2 */
+    { volatile float a = 3.0f, b = 2.0f;
+      if (__builtin_fminimum_numf(a, b) == 2.0f) status |= (1 << 1); }
+
+    /* Bit 2: maximumNumber(2, 3) == 3 */
+    { volatile float a = 2.0f, b = 3.0f;
+      if (__builtin_fmaximum_numf(a, b) == 3.0f) status |= (1 << 2); }
+
+    /* Bit 3: maximumNumber(3, 2) == 3 */
+    { volatile float a = 3.0f, b = 2.0f;
+      if (__builtin_fmaximum_numf(a, b) == 3.0f) status |= (1 << 3); }
+
+    /* Bit 4: minimumNumber(-3, 3) == -3 */
+    { volatile float a = -3.0f, b = 3.0f;
+      if (__builtin_fminimum_numf(a, b) == -3.0f) status |= (1 << 4); }
+
+    /* Bit 5: maximumNumber(-3, 3) == 3 */
+    { volatile float a = -3.0f, b = 3.0f;
+      if (__builtin_fmaximum_numf(a, b) == 3.0f) status |= (1 << 5); }
+
+    /* === NaN handling: return the non-NaN operand === */
+
+    /* Bit 6: minimumNumber(NaN, 5) == 5 */
+    { volatile float a = mk(QNAN), b = 5.0f;
+      if (__builtin_fminimum_numf(a, b) == 5.0f) status |= (1 << 6); }
+
+    /* Bit 7: minimumNumber(5, NaN) == 5 */
+    { volatile float a = 5.0f, b = mk(QNAN);
+      if (__builtin_fminimum_numf(a, b) == 5.0f) status |= (1 << 7); }
+
+    /* Bit 8: maximumNumber(NaN, 5) == 5 */
+    { volatile float a = mk(QNAN), b = 5.0f;
+      if (__builtin_fmaximum_numf(a, b) == 5.0f) status |= (1 << 8); }
+
+    /* === Signed zero order: -0 < +0 (the precise behavior) === */
+
+    /* Bit 9: minimumNumber(-0, +0) == -0 */
+    { volatile float a = mk(NZERO), b = mk(PZERO);
+      if (f2u(__builtin_fminimum_numf(a, b)) == NZERO) status |= (1 << 9); }
+
+    /* Bit 10: minimumNumber(+0, -0) == -0 */
+    { volatile float a = mk(PZERO), b = mk(NZERO);
+      if (f2u(__builtin_fminimum_numf(a, b)) == NZERO) status |= (1 << 10); }
+
+    /* Bit 11: maximumNumber(-0, +0) == +0 */
+    { volatile float a = mk(NZERO), b = mk(PZERO);
+      if (f2u(__builtin_fmaximum_numf(a, b)) == PZERO) status |= (1 << 11); }
+
+    /* Bit 12: maximumNumber(+0, -0) == +0 */
+    { volatile float a = mk(PZERO), b = mk(NZERO);
+      if (f2u(__builtin_fmaximum_numf(a, b)) == PZERO) status |= (1 << 12); }
+
+    /* Bit 13: minimumNumber(-0, -0) == -0 */
+    { volatile float a = mk(NZERO), b = mk(NZERO);
+      if (f2u(__builtin_fminimum_numf(a, b)) == NZERO) status |= (1 << 13); }
+
+    /* Bit 14: maximumNumber(+0, +0) == +0 */
+    { volatile float a = mk(PZERO), b = mk(PZERO);
+      if (f2u(__builtin_fmaximum_numf(a, b)) == PZERO) status |= (1 << 14); }
+
+    /* Bit 15: minimumNumber(1.5, -2.5) == -2.5 */
+    { volatile float a = 1.5f, b = -2.5f;
+      if (__builtin_fminimum_numf(a, b) == -2.5f) status |= (1 << 15); }
+
+    return status; /* expect 0xFFFF */
+}


### PR DESCRIPTION
Supports C23 math functions
* [fminimum_num](https://www.gnu.org/software/gnulib/manual/html_node/fminimum_005fnum.html)
* [fmaximum_num](https://www.gnu.org/software/gnulib/manual/html_node/fmaximum_005fnum.html)

Required by Rust `core` library.

Also, fix some issues in elf2rel and Z80 test runner